### PR TITLE
Fix for build-Error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ MAIN="Thesis"
 # Clean-Option prüfen
 if [ "$1" == "clean" ]; then
   echo "🧹 Bereinige temporäre Dateien..."
-  find . -type f \( -name "*.aux" -o -name "*.bbl" -o -name "*.bcf" -o -name "*.blg" -o -name "*.toc" -o -name "*.lof" -o -name "*.lot" -o -name "*.idx" -o -name "*.ilg" -o -name "*.ind" -o -name "*.out" -o -name "*.log" -o -name "*.run.xml" -o -name "*.lol" -o -name "*.synctex.gz" -o -name "*.fls" -o -name "*.fdb_latexmk" -o -name "*.nlo" -o -name "*.nls" \) -delete
+  find . -type f -not -path "./.git/*" \( -name "*.aux" -o -name "*.bbl" -o -name "*.bcf" -o -name "*.blg" -o -name "*.toc" -o -name "*.lof" -o -name "*.lot" -o -name "*.idx" -o -name "*.ilg" -o -name "*.ind" -o -name "*.out" -o -name "*.log" -o -name "*.run.xml" -o -name "*.lol" -o -name "*.synctex.gz" -o -name "*.fls" -o -name "*.fdb_latexmk" -o -name "*.nlo" -o -name "*.nls" \) -delete
   rm -f build.txt build_output.txt
   rm -rf build
   echo "✅ Bereinigung abgeschlossen."


### PR DESCRIPTION
This pull request makes a small but important improvement to the `build.sh` script by ensuring that the clean operation does not delete files inside the `.git` directory.

* Updated the `find` command in `build.sh` to exclude the `.git` directory when deleting temporary files during the clean operation.